### PR TITLE
[improve][doc]Add broker level metrics documentation

### DIFF
--- a/site2/docs/reference-metrics.md
+++ b/site2/docs/reference-metrics.md
@@ -183,8 +183,8 @@ All the broker metrics are labeled with the following labels:
 | pulsar_connection_closed_total_count | Gauge | The total number of closed connections. |
 | pulsar_broker_throttled_connections | Gauge | The number of throttled connections. |
 | pulsar_broker_throttled_connections_global_limit | Gauge | The number of throttled connections due to per-connection limit. |
-| pulsar_broker_topics_count | Gauge | The number of Pulsar topics in this broker. |
-| pulsar_broker_subscriptions_count | Gauge | The number of Pulsar subscriptions in this broker. |
+| pulsar_broker_topics_count | Gauge | The number of pulsar topics in this broker. |
+| pulsar_broker_subscriptions_count | Gauge | The number of pulsar subscriptions in this broker. |
 | pulsar_broker_producers_count | Gauge | The number of active producers connected to this broker. |
 | pulsar_broker_consumers_count | Gauge | The number of active consumers connected to this broker. |
 | pulsar_broker_rate_in | Gauge | The total message rate coming into this broker (message per second). |

--- a/site2/docs/reference-metrics.md
+++ b/site2/docs/reference-metrics.md
@@ -183,6 +183,19 @@ All the broker metrics are labeled with the following labels:
 | pulsar_connection_closed_total_count | Gauge | The total number of closed connections. |
 | pulsar_broker_throttled_connections | Gauge | The number of throttled connections. |
 | pulsar_broker_throttled_connections_global_limit | Gauge | The number of throttled connections due to per-connection limit. |
+| pulsar_broker_topics_count | Gauge | The number of Pulsar topics in this broker. |
+| pulsar_broker_subscriptions_count | Gauge | The number of Pulsar subscriptions in this broker. |
+| pulsar_broker_producers_count | Gauge | The number of active producers connected to this broker. |
+| pulsar_broker_consumers_count | Gauge | The number of active consumers connected to this broker. |
+| pulsar_broker_rate_in | Gauge | The total message rate coming into this broker (message per second). |
+| pulsar_broker_rate_out | Gauge | The total message rate going out from this broker (message per second). |
+| pulsar_broker_throughput_in | Gauge | The total throughput coming into this broker (byte per second). |
+| pulsar_broker_throughput_out | Gauge | The total throughput going out from this broker (byte per second). |
+| pulsar_broker_storage_size | Gauge | The total storage size of all topics in this broker (bytes). |
+| pulsar_broker_storage_logical_size | Gauge | The storage size of all topics in this broker without replicas (in bytes). |
+| pulsar_broker_storage_write_rate | Gauge | The total message batches (entries) written to the storage for this broker (message batch per second). |
+| pulsar_broker_storage_read_rate | Gauge | The total message batches (entries) read from the storage for this broker (message batch per second). |
+| pulsar_broker_msg_backlog | Gauge | The total number of message backlogs in this broker (entries). |
 
 ### BookKeeper client metrics
 


### PR DESCRIPTION
For detailed improvement instructions, please refer to issues：
https://github.com/apache/pulsar/issues/18056

# Motivation
Currently, pulsar does not statistics broker level metrics, and all relevant metrics are 0 by default.

When the number of topic partitions reaches more than 100000 or even millions, and the topic level metrics are exposed (exposeTopicLevelMetricsInPrometheus=true), if you want to query the metrics of the broker dimension, you need to summarize all topics, and the performance becomes very poor, or even the results cannot be queried from the promethus. Common broker level metrics include:
```
pulsar_topics_count
pulsar_subscriptions_count
pulsar_producers_count
pulsar_consumers_count
pulsar_rate_in
pulsar_rate_out
pulsar_throughput_in
pulsar_throughput_out
pulsar_storage_size
pulsar_storage_logical_size
pulsar_storage_write_rate
pulsar_storage_read_rate
pulsar_msg_backlog
```

We need to statistics the metrics of the broker dimension and expose them to prometheus to improve the performance of the monitoring of the broker dimension. Modify the original metrics name as follows:
```
pulsar_broker_topics_count
pulsar_broker_subscriptions_count
pulsar_broker_producers_count
pulsar_broker_consumers_count
pulsar_broker_rate_in
pulsar_broker_rate_out
pulsar_broker_throughput_in
pulsar_broker_throughput_out
pulsar_broker_storage_size
pulsar_broker_storage_logical_size
pulsar_broker_storage_write_rate
pulsar_broker_storage_read_rate
pulsar_broker_msg_backlog
```


- [x] `doc` <!-- Your PR contains doc changes -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->