### PR TITLE
[improve][broker]PIP-255  Add topic metrics for the number of production data requests to add a topic and the average number of messages per request.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
@@ -73,6 +73,7 @@ public class Producer {
     private final String appId;
     private final BrokerInterceptor brokerInterceptor;
     private Rate msgIn;
+    private Rate requestIn;
     private Rate chunkedMessageRate;
     // it records msg-drop rate only for non-persistent topic
     private final Rate msgDrop;
@@ -117,6 +118,7 @@ public class Producer {
         this.closeFuture = new CompletableFuture<>();
         this.appId = appId;
         this.msgIn = new Rate();
+        this.requestIn = new Rate();
         this.chunkedMessageRate = new Rate();
         this.isNonPersistentTopic = topic instanceof NonPersistentTopic;
         this.msgDrop = this.isNonPersistentTopic ? new Rate() : null;
@@ -272,7 +274,7 @@ public class Producer {
     private void publishMessageToTopic(ByteBuf headersAndPayload, long sequenceId, long batchSize, boolean isChunked,
                                        boolean isMarker, Position position) {
         MessagePublishContext messagePublishContext =
-                MessagePublishContext.get(this, sequenceId, msgIn, headersAndPayload.readableBytes(),
+                MessagePublishContext.get(this, sequenceId, msgIn, requestIn, headersAndPayload.readableBytes(),
                         batchSize, isChunked, System.nanoTime(), isMarker, position);
         if (brokerInterceptor != null) {
             brokerInterceptor
@@ -284,7 +286,7 @@ public class Producer {
     private void publishMessageToTopic(ByteBuf headersAndPayload, long lowestSequenceId, long highestSequenceId,
                                        long batchSize, boolean isChunked, boolean isMarker, Position position) {
         MessagePublishContext messagePublishContext = MessagePublishContext.get(this, lowestSequenceId,
-                highestSequenceId, msgIn, headersAndPayload.readableBytes(), batchSize,
+                highestSequenceId, msgIn, requestIn, headersAndPayload.readableBytes(), batchSize,
                 isChunked, System.nanoTime(), isMarker, position);
         if (brokerInterceptor != null) {
             brokerInterceptor
@@ -377,6 +379,7 @@ public class Producer {
         private long ledgerId;
         private long entryId;
         private Rate rateIn;
+        private Rate requestIn;
         private int msgSize;
         private long batchSize;
         private boolean chunked;
@@ -537,6 +540,7 @@ public class Producer {
 
             // stats
             rateIn.recordMultipleEvents(batchSize, msgSize);
+            requestIn.recordMultipleEvents(1L, batchSize);
             producer.topic.recordAddLatency(System.nanoTime() - startTimeNs, TimeUnit.NANOSECONDS);
             producer.cnx.getCommandSender().sendSendReceiptResponse(producer.producerId, sequenceId, highestSequenceId,
                     ledgerId, entryId);
@@ -552,12 +556,13 @@ public class Producer {
             recycle();
         }
 
-        static MessagePublishContext get(Producer producer, long sequenceId, Rate rateIn, int msgSize,
+        static MessagePublishContext get(Producer producer, long sequenceId, Rate rateIn, Rate requestIn, int msgSize,
                 long batchSize, boolean chunked, long startTimeNs, boolean isMarker, Position position) {
             MessagePublishContext callback = RECYCLER.get();
             callback.producer = producer;
             callback.sequenceId = sequenceId;
             callback.rateIn = rateIn;
+            callback.requestIn = requestIn;
             callback.msgSize = msgSize;
             callback.batchSize = batchSize;
             callback.chunked = chunked;
@@ -574,12 +579,14 @@ public class Producer {
         }
 
         static MessagePublishContext get(Producer producer, long lowestSequenceId, long highestSequenceId, Rate rateIn,
-                int msgSize, long batchSize, boolean chunked, long startTimeNs, boolean isMarker, Position position) {
+               Rate requestIn, int msgSize, long batchSize, boolean chunked, long startTimeNs, boolean isMarker,
+                                         Position position) {
             MessagePublishContext callback = RECYCLER.get();
             callback.producer = producer;
             callback.sequenceId = lowestSequenceId;
             callback.highestSequenceId = highestSequenceId;
             callback.rateIn = rateIn;
+            callback.requestIn = requestIn;
             callback.msgSize = msgSize;
             callback.batchSize = batchSize;
             callback.originalProducerName = null;
@@ -629,6 +636,7 @@ public class Producer {
             originalSequenceId = -1L;
             originalHighestSequenceId = -1L;
             rateIn = null;
+            requestIn = null;
             msgSize = 0;
             ledgerId = -1L;
             entryId = -1L;
@@ -730,10 +738,13 @@ public class Producer {
 
     public void updateRates() {
         msgIn.calculateRate();
+        requestIn.calculateRate();
         chunkedMessageRate.calculateRate();
         stats.msgRateIn = msgIn.getRate();
         stats.msgThroughputIn = msgIn.getValueRate();
         stats.averageMsgSize = msgIn.getAverageValue();
+        stats.requestRateIn = requestIn.getRate();
+        stats.averageMsgPerRequest = requestIn.getAverageValue();
         stats.chunkedMessageRate = chunkedMessageRate.getRate();
         if (chunkedMessageRate.getCount() > 0 && this.topic instanceof PersistentTopic) {
             ((PersistentTopic) this.topic).msgChunkPublished = true;
@@ -813,7 +824,7 @@ public class Producer {
             return;
         }
         MessagePublishContext messagePublishContext =
-                MessagePublishContext.get(this, sequenceId, highSequenceId, msgIn,
+                MessagePublishContext.get(this, sequenceId, highSequenceId, msgIn, requestIn,
                         headersAndPayload.readableBytes(), batchSize, isChunked, System.nanoTime(), isMarker, null);
         if (brokerInterceptor != null) {
             brokerInterceptor

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -2168,6 +2168,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             PublisherStatsImpl publisherStats = producer.getStats();
             stats.msgRateIn += publisherStats.msgRateIn;
             stats.msgThroughputIn += publisherStats.msgThroughputIn;
+            stats.requestRateIn += publisherStats.requestRateIn;
 
             if (producer.isRemote()) {
                 remotePublishersStats.put(producer.getRemoteCluster(), publisherStats);
@@ -2176,6 +2177,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             }
         });
 
+        stats.averageMsgPerRequest = stats.msgRateIn == 0.0 ? 0.0 : (stats.msgRateIn / stats.requestRateIn);
         stats.averageMsgSize = stats.msgRateIn == 0.0 ? 0.0 : (stats.msgThroughputIn / stats.msgRateIn);
         stats.msgInCounter = getMsgInCounter();
         stats.bytesInCounter = getBytesInCounter();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/AggregatedProducerStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/AggregatedProducerStats.java
@@ -28,4 +28,8 @@ public class AggregatedProducerStats {
 
     public double averageMsgSize;
 
+    public double requestRateIn;
+
+    public double averageMsgPerRequest;
+
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregator.java
@@ -217,6 +217,8 @@ public class NamespaceStatsAggregator {
                 stats.producersCount++;
                 stats.rateIn += producer.getStats().msgRateIn;
                 stats.throughputIn += producer.getStats().msgThroughputIn;
+                stats.requestRateIn += producer.getStats().requestRateIn;
+                stats.averageMsgPerRequest += producer.getStats().averageMsgPerRequest;
 
                 if (includeProducerMetrics) {
                     AggregatedProducerStats producerStats = stats.producerStats.computeIfAbsent(
@@ -225,6 +227,8 @@ public class NamespaceStatsAggregator {
                     producerStats.msgRateIn = producer.getStats().msgRateIn;
                     producerStats.msgThroughputIn = producer.getStats().msgThroughputIn;
                     producerStats.averageMsgSize = producer.getStats().averageMsgSize;
+                    producerStats.requestRateIn = producer.getStats().requestRateIn;
+                    producerStats.averageMsgPerRequest = producer.getStats().averageMsgPerRequest;
                 }
             }
         });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregator.java
@@ -218,7 +218,6 @@ public class NamespaceStatsAggregator {
                 stats.rateIn += producer.getStats().msgRateIn;
                 stats.throughputIn += producer.getStats().msgThroughputIn;
                 stats.requestRateIn += producer.getStats().requestRateIn;
-                stats.averageMsgPerRequest += producer.getStats().averageMsgPerRequest;
 
                 if (includeProducerMetrics) {
                     AggregatedProducerStats producerStats = stats.producerStats.computeIfAbsent(
@@ -232,6 +231,7 @@ public class NamespaceStatsAggregator {
                 }
             }
         });
+        stats.averageMsgPerRequest = stats.rateIn / stats.requestRateIn;
 
         if (topic instanceof PersistentTopic) {
             tStatus.subscriptions.forEach((subName, subscriptionStats) -> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TopicStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TopicStats.java
@@ -37,6 +37,8 @@ class TopicStats {
     double rateOut;
     double throughputIn;
     double throughputOut;
+    double requestRateIn;
+    double averageMsgPerRequest;
     long msgInCounter;
     long bytesInCounter;
     long msgOutCounter;
@@ -81,6 +83,8 @@ class TopicStats {
         rateOut = 0;
         throughputIn = 0;
         throughputOut = 0;
+        requestRateIn = 0;
+        averageMsgPerRequest = 0;
         bytesInCounter = 0;
         msgInCounter = 0;
         bytesOutCounter = 0;
@@ -132,6 +136,11 @@ class TopicStats {
         writeMetric(stream, "pulsar_throughput_out", stats.throughputOut,
                 cluster, namespace, topic, splitTopicAndPartitionIndexLabel);
         writeMetric(stream, "pulsar_average_msg_size", stats.averageMsgSize,
+                cluster, namespace, topic, splitTopicAndPartitionIndexLabel);
+
+        writeMetric(stream, "pulsar_request_rate_in", stats.requestRateIn,
+                cluster, namespace, topic, splitTopicAndPartitionIndexLabel);
+        writeMetric(stream, "pulsar_average_msg_per_request", stats.averageMsgPerRequest,
                 cluster, namespace, topic, splitTopicAndPartitionIndexLabel);
 
         writeMetric(stream, "pulsar_txn_tb_active_total", stats.ongoingTxnCount,
@@ -257,6 +266,10 @@ class TopicStats {
             writeProducerMetric(stream, "pulsar_producer_msg_throughput_in", producerStats.msgThroughputIn,
                     cluster, namespace, topic, p, producerStats.producerId, splitTopicAndPartitionIndexLabel);
             writeProducerMetric(stream, "pulsar_producer_msg_average_Size", producerStats.averageMsgSize,
+                    cluster, namespace, topic, p, producerStats.producerId, splitTopicAndPartitionIndexLabel);
+            writeProducerMetric(stream, "pulsar_producer_request_in", producerStats.requestRateIn,
+                    cluster, namespace, topic, p, producerStats.producerId, splitTopicAndPartitionIndexLabel);
+            writeProducerMetric(stream, "pulsar_producer_avg_msg_per_request", producerStats.averageMsgPerRequest,
                     cluster, namespace, topic, p, producerStats.producerId, splitTopicAndPartitionIndexLabel);
         });
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/PublisherStatsImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/PublisherStatsImpl.java
@@ -43,6 +43,12 @@ public class PublisherStatsImpl implements PublisherStats {
     /** Average message size published by this publisher. */
     public double averageMsgSize;
 
+    /** Total rate of request published by this publisher (request/s). */
+    public double requestRateIn;
+
+    /** Average number of messages per entry by this publisher (msg/request). */
+    public double averageMsgPerRequest;
+
     /** The total rate of chunked messages published by this publisher. **/
     public double chunkedMessageRate;
 
@@ -95,6 +101,8 @@ public class PublisherStatsImpl implements PublisherStats {
         this.msgThroughputIn += stats.msgThroughputIn;
         double newAverageMsgSize = (this.averageMsgSize * (this.count - 1) + stats.averageMsgSize) / this.count;
         this.averageMsgSize = newAverageMsgSize;
+        this.requestRateIn += stats.requestRateIn;
+        this.averageMsgPerRequest += stats.averageMsgPerRequest;
         return this;
     }
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/PublisherStatsImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/PublisherStatsImpl.java
@@ -101,8 +101,10 @@ public class PublisherStatsImpl implements PublisherStats {
         this.msgThroughputIn += stats.msgThroughputIn;
         double newAverageMsgSize = (this.averageMsgSize * (this.count - 1) + stats.averageMsgSize) / this.count;
         this.averageMsgSize = newAverageMsgSize;
+        double newAverageMsgPerRequest = (this.averageMsgPerRequest * (this.count - 1) + stats.averageMsgPerRequest)
+                / this.count;
+        this.averageMsgPerRequest = newAverageMsgPerRequest;
         this.requestRateIn += stats.requestRateIn;
-        this.averageMsgPerRequest += stats.averageMsgPerRequest;
         return this;
     }
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/TopicStatsImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/TopicStatsImpl.java
@@ -51,6 +51,12 @@ public class TopicStatsImpl implements TopicStats {
     /** Total rate of messages published on the topic (msg/s). */
     public double msgRateIn;
 
+    /** Total rate of request published on the topic (request/s). */
+    public double requestRateIn;
+
+    /** Average number of messages per entry on the topic (msg/request). */
+    public double averageMsgPerRequest;
+
     /** Total throughput of messages published on the topic (byte/s). */
     public double msgThroughputIn;
 
@@ -191,6 +197,8 @@ public class TopicStatsImpl implements TopicStats {
     public void reset() {
         this.count = 0;
         this.msgRateIn = 0;
+        this.requestRateIn = 0;
+        this.averageMsgPerRequest = 0;
         this.msgThroughputIn = 0;
         this.msgRateOut = 0;
         this.msgThroughputOut = 0;
@@ -238,6 +246,10 @@ public class TopicStatsImpl implements TopicStats {
         this.waitingPublishers += stats.waitingPublishers;
         double newAverageMsgSize = (this.averageMsgSize * (this.count - 1) + stats.averageMsgSize) / this.count;
         this.averageMsgSize = newAverageMsgSize;
+        this.requestRateIn = stats.requestRateIn;
+        double newAverageMsgPerRequest = (this.averageMsgPerRequest * (this.count - 1) + stats.averageMsgPerRequest)
+                / this.count;
+        this.averageMsgPerRequest = newAverageMsgPerRequest;
         this.storageSize += stats.storageSize;
         this.backlogSize += stats.backlogSize;
         this.publishRateLimitedTimes += stats.publishRateLimitedTimes;

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/PublisherStatsTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/PublisherStatsTest.java
@@ -40,6 +40,8 @@ public class PublisherStatsTest {
             "msgRateIn",
             "msgThroughputIn",
             "averageMsgSize",
+            "requestRateIn",
+            "averageMsgPerRequest",
             "chunkedMessageRate",
             "producerId",
             "metadata",


### PR DESCRIPTION
### Motivation
In the current topic level monitoring, there is no metrics to monitor the number of send data requests and the number of messages per send request (i.e., each entry) for a topic. This is inconvenient for us to troubleshoot the following issues:

1. In cases where the client does not perform batch data writing or the batch written messages are not very reasonable, we cannot intuitively reflect through monitoring and cannot detect unreasonable business usage in a timely manner; It has a significant impact on production and consumption performance, increasing cluster load, reducing cluster performance, and increasing overall costs;

2. When we enable the production flow limiting strategy, if the flow limiting condition is triggered by the number of requests on a single connection, it is difficult to accurately locate which topic's high-frequency send data is causing it;

### Modifications
Add four metrics:
`pulsar_request_rate_in`: Topic send request rate.
`pulsar_average_msg_per_request`: Average number of messages per send request for topic.

`pulsar_producer_request_in`: producer send request rate.
`pulsar_producer_avg_msg_per_request`: Average number of messages per send request for producer.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [x] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [x] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
