### PR TITLE
[improve][broker]PIP-340 Optimization of Probe Implementation for Automatic Failover

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/ClusterHealthStatusResources.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/ClusterHealthStatusResources.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.resources;
+
+import java.util.Optional;
+import java.util.function.Function;
+import org.apache.pulsar.metadata.api.MetadataStore;
+import org.apache.pulsar.metadata.api.MetadataStoreException;
+
+public class ClusterHealthStatusResources extends BaseResources<String> {
+    public static final String BASE_PATH = "/health-status/";
+
+    public ClusterHealthStatusResources(MetadataStore store, int operationTimeoutSec) {
+        super(store, String.class, operationTimeoutSec);
+    }
+
+    public void updateHealthStatus(String clusterName, Function<String, String> modifyFunction)
+            throws MetadataStoreException {
+        set(joinPath(BASE_PATH, clusterName), modifyFunction);
+    }
+
+    public Optional<String> getHealthStatus(String clusterName) throws MetadataStoreException {
+        return get(joinPath(BASE_PATH, clusterName));
+    }
+
+    public enum Status {
+        available,
+        unavailable
+    }
+}

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/PulsarResources.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/PulsarResources.java
@@ -34,6 +34,8 @@ public class PulsarResources {
     @Getter
     private final ClusterResources clusterResources;
     @Getter
+    private final ClusterHealthStatusResources clusterHealthStatusResources;
+    @Getter
     private final ResourceGroupResources resourcegroupResources;
     @Getter
     private final NamespaceResources namespaceResources;
@@ -63,11 +65,14 @@ public class PulsarResources {
             tenantResources = new TenantResources(configurationMetadataStore, operationTimeoutSec);
             clusterResources = new ClusterResources(localMetadataStore, configurationMetadataStore,
                     operationTimeoutSec);
+            clusterHealthStatusResources = new ClusterHealthStatusResources(localMetadataStore,
+                    operationTimeoutSec);
             namespaceResources = new NamespaceResources(configurationMetadataStore, operationTimeoutSec);
             resourcegroupResources = new ResourceGroupResources(configurationMetadataStore, operationTimeoutSec);
         } else {
             tenantResources = null;
             clusterResources = null;
+            clusterHealthStatusResources = null;
             namespaceResources  = null;
             resourcegroupResources = null;
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -96,6 +97,7 @@ import org.apache.pulsar.broker.qos.MonotonicSnapshotClock;
 import org.apache.pulsar.broker.resourcegroup.ResourceGroupService;
 import org.apache.pulsar.broker.resourcegroup.ResourceUsageTopicTransportManager;
 import org.apache.pulsar.broker.resourcegroup.ResourceUsageTransportManager;
+import org.apache.pulsar.broker.resources.ClusterHealthStatusResources;
 import org.apache.pulsar.broker.resources.ClusterResources;
 import org.apache.pulsar.broker.resources.PulsarResources;
 import org.apache.pulsar.broker.rest.Topics;
@@ -751,6 +753,14 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                     : null;
             localMetadataStore = createLocalMetadataStore(localMetadataSynchronizer);
             localMetadataStore.registerSessionListener(this::handleMetadataSessionEvent);
+
+            String healthStatusPath = ClusterHealthStatusResources.BASE_PATH
+                    + config.getClusterName();
+            if (!localMetadataStore.exists(healthStatusPath).get(30000, TimeUnit.MICROSECONDS)) {
+                localMetadataStore.put(healthStatusPath,
+                        ClusterHealthStatusResources.Status.available.name().getBytes(StandardCharsets.UTF_8),
+                        Optional.of(-1L));
+            }
 
             coordinationService = new CoordinationServiceImpl(localMetadataStore);
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -62,6 +62,7 @@ import org.apache.pulsar.broker.loadbalance.extensions.data.BrokerLookupData;
 import org.apache.pulsar.broker.namespace.LookupOptions;
 import org.apache.pulsar.broker.namespace.NamespaceService;
 import org.apache.pulsar.broker.resources.BookieResources;
+import org.apache.pulsar.broker.resources.ClusterHealthStatusResources;
 import org.apache.pulsar.broker.resources.ClusterResources;
 import org.apache.pulsar.broker.resources.DynamicConfigurationResources;
 import org.apache.pulsar.broker.resources.LoadBalanceResources;
@@ -1102,6 +1103,10 @@ public abstract class PulsarWebResource {
 
     protected ClusterResources clusterResources() {
         return pulsar().getPulsarResources().getClusterResources();
+    }
+
+    protected ClusterHealthStatusResources clusterHealthStatusResources() {
+        return pulsar().getPulsarResources().getClusterHealthStatusResources();
     }
 
     protected BookieResources bookieResources() {

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Clusters.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Clusters.java
@@ -809,4 +809,31 @@ public interface Clusters {
      */
     CompletableFuture<FailureDomain> getFailureDomainAsync(String cluster, String domainName);
 
+    /**
+     * Update health status for a cluster.
+     * <p/>
+     *
+     * @param cluster
+     *          Cluster name
+     *
+     * @param status
+     *          health status
+     *
+     * @return
+     *
+     */
+    CompletableFuture<Void> updateHealthStatusAsync(String cluster, String status);
+
+    /**
+     * Get health status for a cluster.
+     * <p/>
+     *
+     * @param cluster
+     *          Cluster name
+     *
+     * @return
+     *
+     */
+    CompletableFuture<String> getHealthStatusAsync(String cluster);
+
 }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/ClustersImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/ClustersImpl.java
@@ -319,6 +319,21 @@ public class ClustersImpl extends BaseResource implements Clusters {
                 .thenApply(failureDomain -> failureDomain);
     }
 
+    @Override
+    public CompletableFuture<Void> updateHealthStatusAsync(String cluster, String status) {
+        WebTarget path = adminClusters.path(cluster).path("updateHealthStatus");
+        Map<String, String> statusMap = new HashMap<>();
+        statusMap.put("status", status);
+        return asyncPostRequest(path, Entity.entity(statusMap, MediaType.APPLICATION_JSON_TYPE));
+    }
+
+    @Override
+    public CompletableFuture<String> getHealthStatusAsync(String cluster) {
+        WebTarget path = adminClusters.path(cluster).path("getHealthStatus");
+        return asyncGetRequest(path,  new FutureCallback<String>() {})
+                .thenApply(status -> status);
+    }
+
     private void setDomain(String cluster, String domainName,
                            FailureDomain domain) throws PulsarAdminException {
         sync(() -> setDomainAsync(cluster, domainName, domain));

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdClusters.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdClusters.java
@@ -286,6 +286,31 @@ public class CmdClusters extends CmdBase {
         }
     }
 
+    @Parameters(commandDescription = "Update cluster health status, available or unavailable. default available.")
+    private class UpdateHealthStatus extends CliCommand {
+        @Parameter(description = "cluster-name", required = true)
+        private java.util.List<String> params;
+
+        @Parameter(names = "--status", description = "status", required = true)
+        private String status;
+
+        void run() throws PulsarAdminException {
+            String cluster = getOneArgument(params);
+            getAdmin().clusters().updateHealthStatusAsync(cluster, status);
+        }
+    }
+
+    @Parameters(commandDescription = "Get cluster health status, available or unavailable.")
+    private class GetHealthStatus extends CliCommand {
+        @Parameter(description = "cluster-name", required = true)
+        private java.util.List<String> params;
+
+        void run() throws PulsarAdminException {
+            String cluster = getOneArgument(params);
+            print(getAdmin().clusters().getHealthStatusAsync(cluster));
+        }
+    }
+
     /**
      * Base command.
      */
@@ -493,6 +518,8 @@ public class CmdClusters extends CmdBase {
         jcommander.addCommand("update-failure-domain", new UpdateFailureDomain());
         jcommander.addCommand("delete-failure-domain", new DeleteFailureDomain());
         jcommander.addCommand("list-failure-domains", new ListFailureDomains());
+        jcommander.addCommand("update-health-status", new UpdateHealthStatus());
+        jcommander.addCommand("get-health-status", new GetHealthStatus());
     }
 
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
@@ -38,6 +38,7 @@ import java.util.Optional;
 import java.util.Set;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
+import lombok.val;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Triple;
 import org.apache.pulsar.PulsarVersion;
@@ -47,61 +48,15 @@ import org.apache.pulsar.client.api.Range;
 import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
 import org.apache.pulsar.common.api.AuthData;
-import org.apache.pulsar.common.api.proto.AuthMethod;
-import org.apache.pulsar.common.api.proto.BaseCommand;
+import org.apache.pulsar.common.api.proto.*;
 import org.apache.pulsar.common.api.proto.BaseCommand.Type;
-import org.apache.pulsar.common.api.proto.BrokerEntryMetadata;
-import org.apache.pulsar.common.api.proto.CommandAck;
 import org.apache.pulsar.common.api.proto.CommandAck.AckType;
 import org.apache.pulsar.common.api.proto.CommandAck.ValidationError;
-import org.apache.pulsar.common.api.proto.CommandAckResponse;
-import org.apache.pulsar.common.api.proto.CommandAddPartitionToTxn;
-import org.apache.pulsar.common.api.proto.CommandAddPartitionToTxnResponse;
-import org.apache.pulsar.common.api.proto.CommandAddSubscriptionToTxn;
-import org.apache.pulsar.common.api.proto.CommandAddSubscriptionToTxnResponse;
-import org.apache.pulsar.common.api.proto.CommandAuthChallenge;
-import org.apache.pulsar.common.api.proto.CommandCloseConsumer;
-import org.apache.pulsar.common.api.proto.CommandCloseProducer;
-import org.apache.pulsar.common.api.proto.CommandConnect;
-import org.apache.pulsar.common.api.proto.CommandConnected;
-import org.apache.pulsar.common.api.proto.CommandEndTxnOnPartitionResponse;
-import org.apache.pulsar.common.api.proto.CommandEndTxnOnSubscriptionResponse;
-import org.apache.pulsar.common.api.proto.CommandEndTxnResponse;
-import org.apache.pulsar.common.api.proto.CommandGetLastMessageIdResponse;
-import org.apache.pulsar.common.api.proto.CommandGetSchema;
-import org.apache.pulsar.common.api.proto.CommandGetSchemaResponse;
-import org.apache.pulsar.common.api.proto.CommandGetTopicsOfNamespace;
 import org.apache.pulsar.common.api.proto.CommandGetTopicsOfNamespace.Mode;
-import org.apache.pulsar.common.api.proto.CommandGetTopicsOfNamespaceResponse;
-import org.apache.pulsar.common.api.proto.CommandLookupTopic;
-import org.apache.pulsar.common.api.proto.CommandLookupTopicResponse;
 import org.apache.pulsar.common.api.proto.CommandLookupTopicResponse.LookupType;
-import org.apache.pulsar.common.api.proto.CommandMessage;
-import org.apache.pulsar.common.api.proto.CommandNewTxnResponse;
-import org.apache.pulsar.common.api.proto.CommandPartitionedTopicMetadataResponse;
-import org.apache.pulsar.common.api.proto.CommandProducer;
-import org.apache.pulsar.common.api.proto.CommandProducerSuccess;
-import org.apache.pulsar.common.api.proto.CommandRedeliverUnacknowledgedMessages;
-import org.apache.pulsar.common.api.proto.CommandSeek;
-import org.apache.pulsar.common.api.proto.CommandSend;
-import org.apache.pulsar.common.api.proto.CommandSubscribe;
 import org.apache.pulsar.common.api.proto.CommandSubscribe.InitialPosition;
 import org.apache.pulsar.common.api.proto.CommandSubscribe.SubType;
-import org.apache.pulsar.common.api.proto.CommandTcClientConnectResponse;
 import org.apache.pulsar.common.api.proto.CommandTopicMigrated.ResourceType;
-import org.apache.pulsar.common.api.proto.FeatureFlags;
-import org.apache.pulsar.common.api.proto.IntRange;
-import org.apache.pulsar.common.api.proto.KeySharedMeta;
-import org.apache.pulsar.common.api.proto.KeySharedMode;
-import org.apache.pulsar.common.api.proto.KeyValue;
-import org.apache.pulsar.common.api.proto.MessageIdData;
-import org.apache.pulsar.common.api.proto.MessageMetadata;
-import org.apache.pulsar.common.api.proto.ProtocolVersion;
-import org.apache.pulsar.common.api.proto.Schema;
-import org.apache.pulsar.common.api.proto.ServerError;
-import org.apache.pulsar.common.api.proto.SingleMessageMetadata;
-import org.apache.pulsar.common.api.proto.Subscription;
-import org.apache.pulsar.common.api.proto.TxnAction;
 import org.apache.pulsar.common.intercept.BrokerEntryMetadataInterceptor;
 import org.apache.pulsar.common.protocol.schema.SchemaVersion;
 import org.apache.pulsar.common.schema.SchemaInfo;
@@ -190,6 +145,18 @@ public class Commands {
         flags.setSupportsAuthRefresh(true);
         flags.setSupportsBrokerEntryMetadata(true);
         flags.setSupportsPartialProducer(true);
+    }
+
+    public static ByteBuf newHealthCheck() {
+        BaseCommand cmd = localCmd(Type.HEALTH_CHECK);
+        cmd.setHealthCheck();
+        return serializeWithSize(cmd);
+    }
+
+    public static ByteBuf newHealthCheckResponse(boolean available) {
+        BaseCommand cmd = localCmd(Type.HEALTH_CHECK_RESPONSE);
+        cmd.setHealthCheckResponse().setAvailable(available);
+        return serializeWithSize(cmd);
     }
 
     public static ByteBuf newConnect(String authMethodName, String authData, int protocolVersion, String libVersion,

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/PulsarDecoder.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/PulsarDecoder.java
@@ -24,66 +24,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelOutboundInvoker;
 import io.netty.handler.codec.haproxy.HAProxyMessage;
-import org.apache.pulsar.common.api.proto.BaseCommand;
-import org.apache.pulsar.common.api.proto.CommandAck;
-import org.apache.pulsar.common.api.proto.CommandAckResponse;
-import org.apache.pulsar.common.api.proto.CommandActiveConsumerChange;
-import org.apache.pulsar.common.api.proto.CommandAddPartitionToTxn;
-import org.apache.pulsar.common.api.proto.CommandAddPartitionToTxnResponse;
-import org.apache.pulsar.common.api.proto.CommandAddSubscriptionToTxn;
-import org.apache.pulsar.common.api.proto.CommandAddSubscriptionToTxnResponse;
-import org.apache.pulsar.common.api.proto.CommandAuthChallenge;
-import org.apache.pulsar.common.api.proto.CommandAuthResponse;
-import org.apache.pulsar.common.api.proto.CommandCloseConsumer;
-import org.apache.pulsar.common.api.proto.CommandCloseProducer;
-import org.apache.pulsar.common.api.proto.CommandConnect;
-import org.apache.pulsar.common.api.proto.CommandConnected;
-import org.apache.pulsar.common.api.proto.CommandConsumerStats;
-import org.apache.pulsar.common.api.proto.CommandConsumerStatsResponse;
-import org.apache.pulsar.common.api.proto.CommandEndTxn;
-import org.apache.pulsar.common.api.proto.CommandEndTxnOnPartition;
-import org.apache.pulsar.common.api.proto.CommandEndTxnOnPartitionResponse;
-import org.apache.pulsar.common.api.proto.CommandEndTxnOnSubscription;
-import org.apache.pulsar.common.api.proto.CommandEndTxnOnSubscriptionResponse;
-import org.apache.pulsar.common.api.proto.CommandEndTxnResponse;
-import org.apache.pulsar.common.api.proto.CommandError;
-import org.apache.pulsar.common.api.proto.CommandFlow;
-import org.apache.pulsar.common.api.proto.CommandGetLastMessageId;
-import org.apache.pulsar.common.api.proto.CommandGetLastMessageIdResponse;
-import org.apache.pulsar.common.api.proto.CommandGetOrCreateSchema;
-import org.apache.pulsar.common.api.proto.CommandGetOrCreateSchemaResponse;
-import org.apache.pulsar.common.api.proto.CommandGetSchema;
-import org.apache.pulsar.common.api.proto.CommandGetSchemaResponse;
-import org.apache.pulsar.common.api.proto.CommandGetTopicsOfNamespace;
-import org.apache.pulsar.common.api.proto.CommandGetTopicsOfNamespaceResponse;
-import org.apache.pulsar.common.api.proto.CommandLookupTopic;
-import org.apache.pulsar.common.api.proto.CommandLookupTopicResponse;
-import org.apache.pulsar.common.api.proto.CommandMessage;
-import org.apache.pulsar.common.api.proto.CommandNewTxn;
-import org.apache.pulsar.common.api.proto.CommandNewTxnResponse;
-import org.apache.pulsar.common.api.proto.CommandPartitionedTopicMetadata;
-import org.apache.pulsar.common.api.proto.CommandPartitionedTopicMetadataResponse;
-import org.apache.pulsar.common.api.proto.CommandPing;
-import org.apache.pulsar.common.api.proto.CommandPong;
-import org.apache.pulsar.common.api.proto.CommandProducer;
-import org.apache.pulsar.common.api.proto.CommandProducerSuccess;
-import org.apache.pulsar.common.api.proto.CommandReachedEndOfTopic;
-import org.apache.pulsar.common.api.proto.CommandRedeliverUnacknowledgedMessages;
-import org.apache.pulsar.common.api.proto.CommandSeek;
-import org.apache.pulsar.common.api.proto.CommandSend;
-import org.apache.pulsar.common.api.proto.CommandSendError;
-import org.apache.pulsar.common.api.proto.CommandSendReceipt;
-import org.apache.pulsar.common.api.proto.CommandSubscribe;
-import org.apache.pulsar.common.api.proto.CommandSuccess;
-import org.apache.pulsar.common.api.proto.CommandTcClientConnectRequest;
-import org.apache.pulsar.common.api.proto.CommandTcClientConnectResponse;
-import org.apache.pulsar.common.api.proto.CommandTopicMigrated;
-import org.apache.pulsar.common.api.proto.CommandUnsubscribe;
-import org.apache.pulsar.common.api.proto.CommandWatchTopicList;
-import org.apache.pulsar.common.api.proto.CommandWatchTopicListClose;
-import org.apache.pulsar.common.api.proto.CommandWatchTopicListSuccess;
-import org.apache.pulsar.common.api.proto.CommandWatchTopicUpdate;
-import org.apache.pulsar.common.api.proto.ServerError;
+import org.apache.pulsar.common.api.proto.*;
 import org.apache.pulsar.common.intercept.InterceptException;
 import org.apache.pulsar.common.util.netty.NettyChannelUtil;
 import org.slf4j.Logger;
@@ -185,6 +126,16 @@ public abstract class PulsarDecoder extends ChannelInboundHandlerAdapter {
             case CONNECTED:
                 checkArgument(cmd.hasConnected());
                 handleConnected(cmd.getConnected());
+                break;
+
+            case HEALTH_CHECK:
+                checkArgument(cmd.hasHealthCheck());
+                handleHealthCheck(cmd.getHealthCheck());
+                break;
+
+            case HEALTH_CHECK_RESPONSE:
+                checkArgument(cmd.hasHealthCheckResponse());
+                handleHealthCheckResponse(cmd.getHealthCheckResponse());
                 break;
 
             case ERROR:
@@ -526,6 +477,14 @@ public abstract class PulsarDecoder extends ChannelInboundHandlerAdapter {
     }
 
     protected void handleConnected(CommandConnected connected) {
+        throw new UnsupportedOperationException();
+    }
+
+    protected void handleHealthCheck(CommandHealthCheck healthCheck) {
+        throw new UnsupportedOperationException();
+    }
+
+    protected void handleHealthCheckResponse(CommandHealthCheckResponse healthCheckResponse) {
         throw new UnsupportedOperationException();
     }
 

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -295,6 +295,14 @@ message CommandConnect {
     optional string proxy_version = 11; // Version of the proxy. Should only be forwarded by a proxy.
 }
 
+message CommandHealthCheck {
+    repeated KeyValue metadata = 1;
+}
+
+message CommandHealthCheckResponse {
+    optional bool available = 1 [default = true];
+}
+
 message FeatureFlags {
   optional bool supports_auth_refresh = 1 [default = false];
   optional bool supports_broker_entry_metadata = 2 [default = false];
@@ -1049,6 +1057,9 @@ message BaseCommand {
         WATCH_TOPIC_LIST_CLOSE = 67;
 
         TOPIC_MIGRATED = 68;
+
+        HEALTH_CHECK = 69;
+        HEALTH_CHECK_RESPONSE = 70;
     }
 
 
@@ -1132,4 +1143,7 @@ message BaseCommand {
     optional CommandWatchTopicListClose watchTopicListClose = 67;
     
     optional CommandTopicMigrated topicMigrated = 68;
+
+    optional CommandHealthCheck healthCheck = 69;
+    optional CommandHealthCheckResponse healthCheckResponse = 70;
 }


### PR DESCRIPTION
### Motivation

The current Java client implementation has certain flaws in automatic fault switching.

```
org.apache.pulsar.client.impl.AutoClusterFailover.java
boolean probeAvailable(String url) {
        try {
            resolver.updateServiceUrl(url);
            InetSocketAddress endpoint = resolver.resolveHost();
            Socket socket = new Socket();
            socket.connect(new InetSocketAddress(endpoint.getHostName(), endpoint.getPort()), TIMEOUT);
            socket.close();

            return true
        } catch (Exception e) {
            log.warn("Failed to probe available, url: {}", url, e);
            return false;
        }
    }

```
The client only establishes a TCP connection with the exposed connection address of the cluster to determine whether the cluster is available, which cannot adapt to scenarios where the cluster is partially unavailable (half dead). In this scenario, we hope to make corresponding fault switching judgments by initiating cluster health status requests to the cluster. Then within the cluster, we provide an admin management command to update the cluster's health status. To avoid this scenario, all businesses that need to connect to this cluster need to manually switch cluster connection addresses and restart applications, resulting in inconsistent link data among multiple business team due to inconsistent operation steps.

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

### Modifications

<!-- Describe the modifications you've done. -->
1. Add a new cluster health status request and response request;
```
case HEALTH_CHECK:
	checkArgument(cmd.hasHealthCheck());
	handleHealthCheck(cmd.getHealthCheck());
	break;

case HEALTH_CHECK_RESPONSE:
	checkArgument(cmd.hasHealthCheckResponse());
	handleHealthCheckResponse(cmd.getHealthCheckResponse());
	break;            
```

3. Add a new admin management command to manually update the cluster health status;
```
//Update cluster health status, available or unavailable. default available
bin/pulsar-admin clusters update-health-status --status unavailable
```

For other detailed information, please refer to the PR code.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [x] The binary protocol
- [ ] The REST endpoints
- [x] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->
https://github.com/apache/pulsar/pull/22133
